### PR TITLE
🛡️ Sentinel: [security improvement] Add securityContext to Grafana

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - [Security Context Hardening]
+**Vulnerability:** Grafana deployment lacked standard Kubernetes `securityContext` definitions, allowing potential privilege escalation and running with write access to the root filesystem.
+**Learning:** Grafana requires specific user ID (472) to function correctly when dropping privileges. When enabling `readOnlyRootFilesystem: true`, an `emptyDir` volume must be mounted at `/tmp` to allow the application to write temporary files.
+**Prevention:** Always implement pod-level (`runAsNonRoot`, `runAsUser`) and container-level (`allowPrivilegeEscalation`, `readOnlyRootFilesystem`, `capabilities: drop: ["ALL"]`) security contexts, providing explicit `emptyDir` mounts for required writable directories.

--- a/apps/grafana/deployment.yaml
+++ b/apps/grafana/deployment.yaml
@@ -15,8 +15,19 @@ spec:
       labels:
         app: grafana
     spec:
+      securityContext:
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        runAsNonRoot: true
       containers:
         - name: grafana
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           image: grafana/grafana:12.3.3
           imagePullPolicy: IfNotPresent
           ports:
@@ -34,6 +45,8 @@ spec:
             - configMapRef:
                 name: grafana-configmap
           volumeMounts:
+            - mountPath: /tmp
+              name: tmp-vol
             - mountPath: /var/lib/grafana
               name: grafana-data
             - name: ca-cert
@@ -47,6 +60,8 @@ spec:
               cpu: 250m
               memory: 750Mi
       volumes:
+        - name: tmp-vol
+          emptyDir: {}
         - name: grafana-data
           persistentVolumeClaim:
             claimName: grafana-pvc


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Grafana deployment lacked standard Kubernetes `securityContext` definitions, allowing potential privilege escalation and running with write access to the root filesystem.
🎯 Impact: An attacker compromising the Grafana container could potentially escalate privileges or persist malware on the filesystem.
🔧 Fix: Added pod-level `runAsNonRoot: true`, `runAsUser: 472`, `fsGroup: 472`. Added container-level `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and dropped all capabilities (`capabilities: drop: ["ALL"]`). Added an `emptyDir` mounted at `/tmp` to allow the application to write temporary files.
✅ Verification: `kustomize build apps/grafana` successfully builds the hardened deployment manifest and `yq` verifies the correct syntax of the modified YAML file.

---
*PR created automatically by Jules for task [17233676274422118980](https://jules.google.com/task/17233676274422118980) started by @RealTong*