### PR TITLE
🛡️ Sentinel: [security improvement] Harden Redis securityContext

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-28 - [Harden Redis Security Context]
+**Vulnerability:** Missing Kubernetes securityContext declarations allowed the Redis container to run with more privileges than necessary, including full filesystem write access and lack of privilege escalation prevention.
+**Learning:** Container security can be significantly improved by enforcing `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, and dropping all capabilities. For Redis, user ID 999 is required, and an `emptyDir` must be mounted at `/tmp` to allow necessary write operations when the root filesystem is read-only.
+**Prevention:** Always define a strict `securityContext` for deployments, explicitly setting non-root users and read-only filesystems, providing `emptyDir` volumes only where write access is absolutely required.

--- a/apps/redis/deployment.yaml
+++ b/apps/redis/deployment.yaml
@@ -16,13 +16,22 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
       containers:
         - name: redis
           image: redis:8-alpine
           command:
             - redis-server
             - /usr/local/etc/redis/redis.conf
-
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           envFrom:
             - secretRef:
                 name: redis-secret
@@ -34,6 +43,8 @@ spec:
               mountPath: /usr/local/etc/redis
             - name: redis-storage
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               memory: "128Mi"
@@ -48,3 +59,5 @@ spec:
         - name: redis-storage
           persistentVolumeClaim:
             claimName: redis-pvc
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** The Redis deployment lacked proper `securityContext` hardening, allowing the container to run without explicit user/group restrictions, with full filesystem write access, and with potential privilege escalation capabilities intact.
**Impact:** If a vulnerability were discovered in Redis, an attacker could potentially gain elevated privileges or modify arbitrary files within the container's root filesystem, increasing the risk of container breakout or further cluster compromise.
**Fix:** Applied pod-level `securityContext` enforcing `runAsNonRoot: true` and restricting the process to user/group ID 999. Added container-level `securityContext` to drop all Linux capabilities (`capabilities.drop: ["ALL"]`), prevent privilege escalation (`allowPrivilegeEscalation: false`), and enforce a read-only root filesystem (`readOnlyRootFilesystem: true`). To support required temporary file writes while running a read-only root, an `emptyDir` volume was mounted at `/tmp`.
**Verification:** Run `kustomize build apps/redis` to verify that the generated manifests correctly include the comprehensive `securityContext` directives and the required `/tmp` volume mount.

---
*PR created automatically by Jules for task [16987239189504901104](https://jules.google.com/task/16987239189504901104) started by @RealTong*