### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in sub2api init container

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-22 - SQL Injection in Kubernetes Init Containers
+**Vulnerability:** Init containers executing `psql` commands were interpolating environment variables directly into query strings (e.g., `CREATE DATABASE $DB_POSTGRESDB_DATABASE;`), allowing potential SQL injection via K8s secrets.
+**Learning:** Even within isolated Kubernetes environments, secrets used for database initialization must be sanitized or parameterized. Shell interpolation of secrets into SQL statements is unsafe.
+**Prevention:** Use `psql -v param="value"` for variable interpolation. Use `:'param'` to safely escape string literals and `:"param"` to safely escape identifiers.

--- a/apps/sub2api/deployment.yaml
+++ b/apps/sub2api/deployment.yaml
@@ -28,18 +28,18 @@ spec:
               export PGPASSWORD="$POSTGRES_ADMIN_PASSWORD"
 
               # Create database if not exists (use postgres default database)
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = '$DB_POSTGRESDB_DATABASE'" | grep -q 1 || \
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -c "CREATE DATABASE $DB_POSTGRESDB_DATABASE;"
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -v dbname="$DB_POSTGRESDB_DATABASE" -tc "SELECT 1 FROM pg_database WHERE datname = :'dbname'" | grep -q 1 || \
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -v dbname="$DB_POSTGRESDB_DATABASE" -c "CREATE DATABASE :\"dbname\";"
 
               # Create user if not exists
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -tc "SELECT 1 FROM pg_user WHERE usename = '$DB_POSTGRESDB_USER'" | grep -q 1 || \
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -c "CREATE USER $DB_POSTGRESDB_USER WITH PASSWORD '$DB_POSTGRESDB_PASSWORD';"
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -v dbuser="$DB_POSTGRESDB_USER" -v dbpass="$DB_POSTGRESDB_PASSWORD" -tc "SELECT 1 FROM pg_user WHERE usename = :'dbuser'" | grep -q 1 || \
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -v dbuser="$DB_POSTGRESDB_USER" -v dbpass="$DB_POSTGRESDB_PASSWORD" -c "CREATE USER :\"dbuser\" WITH PASSWORD :'dbpass';"
 
               # Grant privileges
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE $DB_POSTGRESDB_DATABASE TO $DB_POSTGRESDB_USER;"
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d postgres -v dbname="$DB_POSTGRESDB_DATABASE" -v dbuser="$DB_POSTGRESDB_USER" -c "GRANT ALL PRIVILEGES ON DATABASE :\"dbname\" TO :\"dbuser\";"
 
               # Grant schema privileges
-              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d "$DB_POSTGRESDB_DATABASE" -c "GRANT ALL ON SCHEMA public TO $DB_POSTGRESDB_USER;"
+              psql -h postgres.databases.svc.cluster.local -U "$POSTGRES_ADMIN_USER" -d "$DB_POSTGRESDB_DATABASE" -v dbuser="$DB_POSTGRESDB_USER" -c "GRANT ALL ON SCHEMA public TO :\"dbuser\";"
 
               echo "Database initialization completed successfully"
           env:


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Init containers executing `psql` commands were interpolating environment variables directly into query strings (e.g., `CREATE DATABASE $DB_POSTGRESDB_DATABASE;`), allowing potential SQL injection via K8s secrets if secrets contain malicious payloads.
🎯 **Impact**: Potential arbitrary command execution or privilege escalation within the postgres database if a malicious actor was able to control the K8s secrets.
🔧 **Fix**: Modified `psql` execution in the init container to use built-in variable parameterization (`-v dbname="$DB_..."`). This ensures parameters are correctly and safely escaped natively by PostgreSQL instead of relying on unsafe shell interpolation. Used `:'var'` for string literals and `:"var"` for identifiers.
✅ **Verification**: Run `kustomize build apps/sub2api` to confirm manifest builds correctly and syntax is valid.

---
*PR created automatically by Jules for task [10106722885017478757](https://jules.google.com/task/10106722885017478757) started by @RealTong*