### PR TITLE
🛡️ Sentinel: [HIGH] Fix Grafana OAuth insecure email lookup vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-23 - Grafana OAuth Insecure Email Lookup
+**Vulnerability:** Grafana was configured with `oauth_allow_insecure_email_lookup = true`, which could allow users to hijack accounts by spoofing email addresses through OAuth providers.
+**Learning:** Relying on unverified emails from OAuth providers for account lookup can lead to authentication bypass and account takeover.
+**Prevention:** Always ensure `oauth_allow_insecure_email_lookup = false` (or unset) to require secure, verified email lookups.

--- a/apps/grafana/configmap.yaml
+++ b/apps/grafana/configmap.yaml
@@ -9,5 +9,5 @@ data:
     root_url = https://dash.wst.sh/
     
     [auth]
-    oauth_allow_insecure_email_lookup = true
+    oauth_allow_insecure_email_lookup = false
     disable_login_form = false


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `oauth_allow_insecure_email_lookup` was set to `true` in `apps/grafana/configmap.yaml`, meaning Grafana would look up accounts based on unverified email addresses returned by OAuth providers.
🎯 **Impact:** An attacker could potentially hijack an existing user's account by registering an unverified account on an allowed OAuth provider with the victim's email address and using that to log into Grafana.
🔧 **Fix:** Changed `oauth_allow_insecure_email_lookup = true` to `oauth_allow_insecure_email_lookup = false` in the Grafana configuration map to enforce secure, verified email lookups.
✅ **Verification:** Verify that `kustomize build apps/grafana` reflects `oauth_allow_insecure_email_lookup = false` in the config map. No new functionality was broken, and standard kustomize build succeeded across the repository.

*Also added the critical learning to the `.jules/sentinel.md` journal.*

---
*PR created automatically by Jules for task [7267362326876704474](https://jules.google.com/task/7267362326876704474) started by @RealTong*