### PR TITLE
🛡️ Sentinel: [security improvement] Hardened n8n securityContext

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Hardened n8n securityContext
+**Vulnerability:** Missing standard Kubernetes `securityContext` definitions in the n8n deployment, which could allow a compromised container to escalate privileges or modify the root filesystem.
+**Learning:** When applying securityContext hardening to n8n, specific default user IDs are required for correct container operation (e.g., n8n uses 1000). The standard pattern involves pod-level `runAsNonRoot: true`, container-level `allowPrivilegeEscalation: false` and `readOnlyRootFilesystem: true`, along with an `emptyDir` volume mounted at `/tmp`.
+**Prevention:** Ensure standard Kubernetes `securityContext` definitions are included in all deployments across the `apps/` directory, following the established hardening pattern.

--- a/apps/n8n/deployment.yaml
+++ b/apps/n8n/deployment.yaml
@@ -16,10 +16,20 @@ spec:
       labels:
         app: n8n
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       nodeSelector:
         kubernetes.io/hostname: "realtong-server"
       containers:
         - name: n8n
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           image: docker.n8n.io/n8nio/n8n:latest
           ports:
             - containerPort: 5678
@@ -67,6 +77,8 @@ spec:
           volumeMounts:
             - name: n8n-data
               mountPath: /home/node/.n8n
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 100m
@@ -78,4 +90,6 @@ spec:
         - name: n8n-data
           persistentVolumeClaim:
             claimName: n8n-pvc
+        - name: tmp
+          emptyDir: {}
 


### PR DESCRIPTION
**🛡️ Sentinel Security Improvement**

This PR adds a standard Kubernetes `securityContext` to the `n8n` deployment. 

**Vulnerability Context:**
The `n8n` deployment was missing a `securityContext` definition, meaning the container was potentially running with more privileges than necessary, increasing the risk profile in the event of a container compromise.

**Fix Details:**
- Added a pod-level `securityContext` with `runAsNonRoot: true`, `runAsUser: 1000`, `runAsGroup: 1000`, and `fsGroup: 1000`. (User `1000` is the default `node` user in the official image).
- Added a container-level `securityContext` with `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and dropped all capabilities (`capabilities: drop: ["ALL"]`).
- Mounted an `emptyDir` volume at `/tmp` to support write operations required by the read-only root filesystem.
- Documented this security enhancement pattern in `.jules/sentinel.md` as a critical learning.

**Verification:**
- Successfully built manifests locally using `kustomize build apps/n8n`.
- Verified all application manifests in the repository to ensure no regressions using `for d in apps/*; do if [ -d "$d" ]; then kustomize build "$d" > /dev/null; fi; done`.

---
*PR created automatically by Jules for task [15383319057276040430](https://jules.google.com/task/15383319057276040430) started by @RealTong*