### PR TITLE
feat: add automated realtong.cn certificate management

### DIFF
--- a/infrastructure/configs/cert-manager/cloudflare-api-token-external-secret.yaml
+++ b/infrastructure/configs/cert-manager/cloudflare-api-token-external-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-api-token-secret
+  namespace: cert-manager
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: infisical-store
+    kind: ClusterSecretStore
+  target:
+    name: cloudflare-api-token-secret
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: /TLS/CLOUDFLARE_API_TOKEN

--- a/infrastructure/configs/cert-manager/kustomization.yaml
+++ b/infrastructure/configs/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cloudflare-api-token-external-secret.yaml
+  - letsencrypt-cloudflare-clusterissuer.yaml
+  - realtong-cn-wildcard-certificate.yaml

--- a/infrastructure/configs/cert-manager/letsencrypt-cloudflare-clusterissuer.yaml
+++ b/infrastructure/configs/cert-manager/letsencrypt-cloudflare-clusterissuer.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-cloudflare
+spec:
+  acme:
+    email: i@realtong.cn
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-cloudflare-account-key
+    solvers:
+      - selector:
+          dnsZones:
+            - realtong.cn
+        dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token-secret
+              key: api-token

--- a/infrastructure/configs/cert-manager/realtong-cn-wildcard-certificate.yaml
+++ b/infrastructure/configs/cert-manager/realtong-cn-wildcard-certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: realtong-cn-wildcard
+  namespace: default
+spec:
+  secretName: realtong-cn-wildcard-tls
+  privateKey:
+    rotationPolicy: Always
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-cloudflare
+  dnsNames:
+    - realtong.cn
+    - '*.realtong.cn'
+  duration: 2160h
+  renewBefore: 720h

--- a/infrastructure/configs/kustomization.yaml
+++ b/infrastructure/configs/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./external-secrets
+  - ./cert-manager
   - ./notifications
   - ./postgresus

--- a/infrastructure/controllers/ingress-nginx/kustomization.yaml
+++ b/infrastructure/controllers/ingress-nginx/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./external-secrets/
-  - ./ingress-nginx/
-  - ./nfs-provisioner/
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/ingress-nginx/release.yaml
+++ b/infrastructure/controllers/ingress-nginx/release.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nginx-ingress
+  namespace: default
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: "4.13.x"
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+  values:
+    controller:
+      service:
+        type: LoadBalancer
+        loadBalancerIP: 10.0.0.145
+      extraArgs:
+        default-ssl-certificate: default/realtong-cn-wildcard-tls

--- a/infrastructure/controllers/ingress-nginx/repository.yaml
+++ b/infrastructure/controllers/ingress-nginx/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
## Summary
- add cert-manager resources for a Let's Encrypt DNS-01 wildcard certificate for realtong.cn via Cloudflare
- pull the Cloudflare API token from Infisical into the cert-manager namespace
- manage ingress-nginx through Flux and set a default TLS certificate for the shared ingress entrypoint

## Notes
- this keeps existing mkcert/wst.sh ingress certificates untouched for now
- the new wildcard certificate is issued into `default/realtong-cn-wildcard-tls`
- before reconciliation can succeed end-to-end, Infisical needs a secret at `/TLS/CLOUDFLARE_API_TOKEN`

## Validation
- kubectl kustomize infrastructure/configs
- kubectl kustomize infrastructure/controllers
- kubectl apply --dry-run=server -k infrastructure/configs
- kubectl apply --dry-run=server -k infrastructure/controllers
