### PR TITLE
feat: migrate selected apps to realtong.cn

### DIFF
--- a/apps/adguard-home/ingress.yaml
+++ b/apps/adguard-home/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: with-proxyauth-ingress
+  namespace: homelab
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - adg.realtong.cn
+  rules:
+    - host: adg.realtong.cn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homelab
+                port:
+                  number: 3000

--- a/apps/adguard-home/kustomization.yaml
+++ b/apps/adguard-home/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homelab
+resources:
+  - ingress.yaml

--- a/apps/glance/configmap.yaml
+++ b/apps/glance/configmap.yaml
@@ -209,25 +209,25 @@ data:
                     cache: 1m
                     title: SelfHosted
                     sites:
-                      - url: https://dash.wst.sh
+                      - url: https://dash.realtong.cn
                         title: Grafana
                         icon: sh:grafana
-                      - url: https://id.wst.sh
+                      - url: https://id.realtong.cn
                         title: PocketID
                         icon: sh:pocket-id
-                      - url: https://auth.wst.sh
+                      - url: https://auth.realtong.cn
                         title: TinyAuth
                         icon: di:tinyauth
-                      - url: https://adg.wst.sh
+                      - url: https://adg.realtong.cn
                         title: AdGuard Home
                         icon: sh:adguard-home
-                      - url: https://nas.wst.sh
+                      - url: https://nas.realtong.cn
                         title: Synology NAS
                         icon: di:synology-dsm
-                      - url: https://kite.wst.sh
+                      - url: https://kite.realtong.cn
                         title: Kubernetes
                         icon: sh:kubernetes
-                      - url: https://portainer.wst.sh
+                      - url: https://portainer.realtong.cn
                         title: Portainer
                         icon: sh:portainer
                       - url: https://route.wst.sh

--- a/apps/grafana/configmap.yaml
+++ b/apps/grafana/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   grafana.ini: |
     [server]
-    root_url = https://dash.wst.sh/
+    root_url = https://dash.realtong.cn/
     
     [auth]
     oauth_allow_insecure_email_lookup = true

--- a/apps/grafana/ingress.yaml
+++ b/apps/grafana/ingress.yaml
@@ -6,22 +6,20 @@ metadata:
     annotations:
         glance/icon: di:grafana
         glance/name: "Grafana"
-        glance/url: https://dash.wst.sh
+        glance/url: https://dash.realtong.cn
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "25m"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - dash.wst.sh
-          secretName: dash-wst-sh-tls
+              - dash.realtong.cn
     rules:
-        - host: dash.wst.sh
+        - host: dash.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/homeassistant/ingress.yaml
+++ b/apps/homeassistant/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homeassistant-ingress
+  namespace: homelab
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ha.realtong.cn
+  rules:
+    - host: ha.realtong.cn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homeassistant
+                port:
+                  number: 8123

--- a/apps/homeassistant/kustomization.yaml
+++ b/apps/homeassistant/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homelab
+resources:
+  - ingress.yaml

--- a/apps/kite/deployment.yaml
+++ b/apps/kite/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                         protocol: TCP
                   env:
                     - name: HOST
-                      value: "https://kite.wst.sh"
+                      value: "https://kite.realtong.cn"
                     - name: NODE_EXTRA_CA_CERTS
                       value: /etc/ssl/certs/ca-certificates.crt
                     - name: SSL_CERT_FILE

--- a/apps/kite/ingress.yaml
+++ b/apps/kite/ingress.yaml
@@ -10,15 +10,13 @@ metadata:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - kite.wst.sh
-          secretName: kite-wst-sh-tls
+              - kite.realtong.cn
     rules:
-        - host: kite.wst.sh
+        - host: kite.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -26,4 +26,7 @@ resources:
   - ./clickhouse/
   - ./neko-master/
   - ./synology-media-proxy/
+  - ./homeassistant/
+  - ./adguard-home/
+  - ./pve/
   - ./qui/

--- a/apps/pocket-id/deployment.yaml
+++ b/apps/pocket-id/deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - containerPort: 1411
           env:
             - name: APP_URL
-              value: "https://id.wst.sh"
+              value: "https://id.realtong.cn"
             - name: APP_NAME
               value: "RealTong's PocketID"
             - name: TRUST_PROXY

--- a/apps/pocket-id/ingress.yaml
+++ b/apps/pocket-id/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     glance/icon: di:pocket-id
     glance/name: "Pocket ID"
-    glance/url: https://id.wst.sh
+    glance/url: https://id.realtong.cn
     nginx.ingress.kubernetes.io/auth-signin-redirect-param: redirect_uri
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -14,15 +14,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - id.wst.sh
-      secretName: id-wst-sh-tls
+        - id.realtong.cn
   rules:
-    - host: id.wst.sh
+    - host: id.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/portainer/ingress.yaml
+++ b/apps/portainer/ingress.yaml
@@ -6,22 +6,20 @@ metadata:
     annotations:
         glance/icon: di:portainer
         glance/name: "Portainer"
-        glance/url: "https://portainer.wst.sh"
+        glance/url: "https://portainer.realtong.cn"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "25m"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - portainer.wst.sh
-          secretName: portainer-wst-sh-tls
+              - portainer.realtong.cn
     rules:
-        - host: portainer.wst.sh
+        - host: portainer.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/pve/ingress.yaml
+++ b/apps/pve/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pve-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 2048m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/upstream-vhost: 10.0.0.120:8006
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - pve.realtong.cn
+  rules:
+    - host: pve.realtong.cn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: pve
+                port:
+                  number: 8006

--- a/apps/pve/kustomization.yaml
+++ b/apps/pve/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ingress.yaml

--- a/apps/tinyauth/configmap.yaml
+++ b/apps/tinyauth/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tinyauth-configmap
   namespace: auth
 data:
-  TINYAUTH_APPURL: "https://auth.wst.sh"
+  TINYAUTH_APPURL: "https://auth.realtong.cn"
   TINYAUTH_UI_TITLE: "RealTong's TinyAuth"
   TINYAUTH_ANALYTICS_ENABLED: "false" 
 
@@ -12,9 +12,9 @@ data:
   TINYAUTH_SECURE_COOKIE: "true"
 
   TINYAUTH_OAUTH_PROVIDERS_POCKETID_NAME: "Pocket ID"
-  TINYAUTH_OAUTH_PROVIDERS_POCKETID_AUTHURL: "https://id.wst.sh/authorize"
-  TINYAUTH_OAUTH_PROVIDERS_POCKETID_TOKENURL: "https://id.wst.sh/api/oidc/token"
-  TINYAUTH_OAUTH_PROVIDERS_POCKETID_USERINFOURL: "https://id.wst.sh/api/oidc/userinfo"
+  TINYAUTH_OAUTH_PROVIDERS_POCKETID_AUTHURL: "https://id.realtong.cn/authorize"
+  TINYAUTH_OAUTH_PROVIDERS_POCKETID_TOKENURL: "https://id.realtong.cn/api/oidc/token"
+  TINYAUTH_OAUTH_PROVIDERS_POCKETID_USERINFOURL: "https://id.realtong.cn/api/oidc/userinfo"
   TINYAUTH_OAUTH_PROVIDERS_POCKETID_SCOPES: "openid email profile groups"
-  TINYAUTH_OAUTH_PROVIDERS_POCKETID_INSECURE: "true"
+  TINYAUTH_OAUTH_PROVIDERS_POCKETID_INSECURE: "false"
   TINYAUTH_OAUTH_WHITELIST: "i@realtong.cn,i@realtong.com,i@wst.sh"

--- a/apps/tinyauth/ingress.yaml
+++ b/apps/tinyauth/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     glance/icon: di:tinyauth
     glance/name: "TinyAuth"
-    glance/url: "https://auth.wst.sh"
+    glance/url: "https://auth.realtong.cn"
     nginx.ingress.kubernetes.io/auth-signin-redirect-param: redirect_uri
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -14,15 +14,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - auth.wst.sh
-      secretName: auth-wst-sh-tls
+        - auth.realtong.cn
   rules:
-    - host: auth.wst.sh
+    - host: auth.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/vaultwarden/configmap.yaml
+++ b/apps/vaultwarden/configmap.yaml
@@ -7,4 +7,4 @@ data:
   DOMAIN: "https://pwd.wst.sh"
   WEBSOCKET_ENABLED: "true"
   SSO_ENABLED: "true"
-  SSO_AUTHORITY: "https://id.wst.sh"
+  SSO_AUTHORITY: "https://id.realtong.cn"

--- a/infrastructure/controllers/nfs-provisioner/release.yaml
+++ b/infrastructure/controllers/nfs-provisioner/release.yaml
@@ -15,7 +15,7 @@ spec:
         namespace: flux-system
   values:
     nfs:
-      server: nas.wst.sh
+      server: nas.realtong.cn
       path: /volume1/k3s-volume
     storageClass:
       name: nfs-client


### PR DESCRIPTION
## Summary
- migrate selected app entrypoints from wst.sh to realtong.cn
- update Pocket ID, TinyAuth, Grafana, Kite, Portainer, Home Assistant, AdGuard Home, PVE, and related dashboard links
- switch related app config values to the new realtong.cn canonical URLs

## Included host migrations
- ha.wst.sh -> ha.realtong.cn
- nas.wst.sh -> nas.realtong.cn
- auth.wst.sh -> auth.realtong.cn
- dash.wst.sh -> dash.realtong.cn
- pve.wst.sh -> pve.realtong.cn
- kite.wst.sh -> kite.realtong.cn
- id.wst.sh -> id.realtong.cn
- portainer.wst.sh -> portainer.realtong.cn
- adg.wst.sh -> adg.realtong.cn

## Validation
- kubectl apply --dry-run=server for the changed manifests
- kubectl kustomize for newly added app directories
