### PR TITLE
fix: stabilize pocket-id and finish realtong.cn migration

### DIFF
--- a/apps/beszel-hub/ingress.yaml
+++ b/apps/beszel-hub/ingress.yaml
@@ -2,26 +2,24 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: beszel-hub
-    namespace: beszel-hub
+    namespace: observability
     annotations:
         glance/icon: di:beszel
         glance/name: "Beszel Hub"
-        glance/url: https://monitor.wst.sh
+        glance/url: https://monitor.realtong.cn
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "25m"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - monitor.wst.sh
-          secretName: monitor-wst-sh-tls
+              - monitor.realtong.cn
     rules:
-        - host: monitor.wst.sh
+        - host: monitor.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/drizzle-gateway/ingress.yaml
+++ b/apps/drizzle-gateway/ingress.yaml
@@ -10,15 +10,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - db.wst.sh
-      secretName: db-wst-sh-tls
+        - db.realtong.cn
   rules:
-    - host: db.wst.sh
+    - host: db.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/glance/configmap.yaml
+++ b/apps/glance/configmap.yaml
@@ -230,10 +230,10 @@ data:
                       - url: https://portainer.realtong.cn
                         title: Portainer
                         icon: sh:portainer
-                      - url: https://route.wst.sh
+                      - url: https://route.realtong.cn
                         title: OpenWRT
                         icon: sh:openwrt
-                      - url: https://pwd.wst.sh
+                      - url: https://pwd.realtong.cn
                         title: Vaultwarden
                         icon: sh:vaultwarden
                   

--- a/apps/glance/ingress.yaml
+++ b/apps/glance/ingress.yaml
@@ -6,22 +6,20 @@ metadata:
     annotations:
         glance/icon: di:glance
         glance/name: "Glance"
-        glance/url: https://glance.wst.sh
+        glance/url: https://glance.realtong.cn
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "25m"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - glance.wst.sh
-          secretName: glance-wst-sh-tls
+              - glance.realtong.cn
     rules:
-        - host: glance.wst.sh
+        - host: glance.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/n8n/ingress.yaml
+++ b/apps/n8n/ingress.yaml
@@ -6,21 +6,19 @@ metadata:
   annotations:
     glance/icon: di:n8n
     glance/name: "n8n"
-    glance/url: "https://n8n.wst.sh"
+    glance/url: "https://n8n.realtong.cn"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - n8n.wst.sh
-      secretName: n8n-wst-sh-tls
+        - n8n.realtong.cn
   rules:
-    - host: n8n.wst.sh
+    - host: n8n.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/neko-master/ingress.yaml
+++ b/apps/neko-master/ingress.yaml
@@ -9,15 +9,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - clash.wst.sh
-      secretName: clash-wst-sh-tls
+        - clash.realtong.cn
   rules:
-    - host: clash.wst.sh
+    - host: clash.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/openclaw/openclaw-ingress.yaml
+++ b/apps/openclaw/openclaw-ingress.yaml
@@ -6,22 +6,20 @@ metadata:
   annotations:
     glance/icon: carbon:ibm-watson-assistant
     glance/name: "openclaw"
-    glance/url: https://claw.wst.sh
+    glance/url: https://claw.realtong.cn
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - claw.wst.sh
-      secretName: claw-wst-sh-tls
+        - claw.realtong.cn
   rules:
-    - host: claw.wst.sh
+    - host: claw.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/openclaw/route-ingress.yaml
+++ b/apps/openclaw/route-ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: route-ingress
   namespace: homelab
   annotations:
-    cert-manager.io/cluster-issuer: mkcert-issuer
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
@@ -15,10 +14,9 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - route.wst.sh
-      secretName: route-wst-sh-tls
+        - route.realtong.cn
   rules:
-    - host: route.wst.sh
+    - host: route.realtong.cn
       http:
         paths:
           # OpenWRT 主界面

--- a/apps/openstatus/dashboard-deployment.yaml
+++ b/apps/openstatus/dashboard-deployment.yaml
@@ -37,9 +37,9 @@ spec:
             - name: DATABASE_AUTH_TOKEN
               value: ""
             - name: NEXT_PUBLIC_URL
-              value: https://status.wst.sh
+              value: https://status.realtong.cn
             - name: NEXT_PUBLIC_STATUS_PAGE_DOMAIN
-              value: status.wst.sh
+              value: status.realtong.cn
             - name: AUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/apps/openstatus/dashboard-ingress.yaml
+++ b/apps/openstatus/dashboard-ingress.yaml
@@ -6,22 +6,20 @@ metadata:
   annotations:
     glance/icon: di:openstatus
     glance/name: "OpenStatus"
-    glance/url: https://status.wst.sh
+    glance/url: https://status.realtong.cn
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - status.wst.sh
-      secretName: status-wst-sh-tls
+        - status.realtong.cn
   rules:
-    - host: status.wst.sh
+    - host: status.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/openstatus/kustomization.yaml
+++ b/apps/openstatus/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - dashboard-service.yaml
   - status-page-deployment.yaml
   - status-page-service.yaml
+  - wildcard-status-certificate.yaml
   - dashboard-ingress.yaml
   - status-page-ingress.yaml

--- a/apps/openstatus/status-page-deployment.yaml
+++ b/apps/openstatus/status-page-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: DATABASE_AUTH_TOKEN
               value: ""
             - name: NEXT_PUBLIC_URL
-              value: https://status.wst.sh
+              value: https://status.realtong.cn
             - name: AUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/apps/openstatus/status-page-ingress.yaml
+++ b/apps/openstatus/status-page-ingress.yaml
@@ -10,15 +10,14 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - "*.status.wst.sh"
-      secretName: wildcard-status-wst-sh-tls
+        - "*.status.realtong.cn"
+      secretName: wildcard-status-realtong-cn-tls
   rules:
-    - host: "*.status.wst.sh"
+    - host: "*.status.realtong.cn"
       http:
         paths:
           - path: /

--- a/apps/openstatus/wildcard-status-certificate.yaml
+++ b/apps/openstatus/wildcard-status-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-status-realtong-cn
+  namespace: observability
+spec:
+  secretName: wildcard-status-realtong-cn-tls
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-cloudflare
+  privateKey:
+    rotationPolicy: Always
+  dnsNames:
+    - status.realtong.cn
+    - '*.status.realtong.cn'

--- a/apps/pocket-id/deployment.yaml
+++ b/apps/pocket-id/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: pocket-id
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: pocket-id

--- a/apps/portfolio-ibkr/ingress.yaml
+++ b/apps/portfolio-ibkr/ingress.yaml
@@ -9,15 +9,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - portfolio.wst.sh
-      secretName: portfolio-wst-sh-tls
+        - portfolio.realtong.cn
   rules:
-    - host: portfolio.wst.sh
+    - host: portfolio.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/postgresus/release.yaml
+++ b/apps/postgresus/release.yaml
@@ -32,13 +32,13 @@ spec:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
+        cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       hosts:
-        - host: dbb.wst.sh
+        - host: dbb.realtong.cn
           paths:
             - path: /
               pathType: Prefix
       tls:
-        - secretName: dbb-wst-sh-tls
+        - secretName: dbb-realtong-cn-tls
           hosts:
-            - dbb.wst.sh
+            - dbb.realtong.cn

--- a/apps/qui/deployment.yaml
+++ b/apps/qui/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: QUI__OIDC_DISABLE_BUILT_IN_LOGIN
               value: "true"
             - name: QUI__OIDC_REDIRECT_URL
-              value: "https://qb.wst.sh/api/auth/oidc/callback"
+              value: "https://qb.realtong.cn/api/auth/oidc/callback"
             - name: QUI__SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/apps/qui/ingress.yaml
+++ b/apps/qui/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: qui-ingress
   namespace: homelab
   annotations:
-    cert-manager.io/cluster-issuer: mkcert-issuer
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
@@ -14,10 +13,9 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - qb.wst.sh
-      secretName: qb-wst-sh-tls
+        - qb.realtong.cn
   rules:
-    - host: qb.wst.sh
+    - host: qb.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/sub2api/ingress.yaml
+++ b/apps/sub2api/ingress.yaml
@@ -6,22 +6,20 @@ metadata:
   annotations:
     glance/icon: simple-icons:openai
     glance/name: "Sub2API"
-    glance/url: "https://ai.wst.sh"
+    glance/url: "https://ai.realtong.cn"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
-    cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - ai.wst.sh
-      secretName: ai-wst-sh-tls
+        - ai.realtong.cn
   rules:
-    - host: ai.wst.sh
+    - host: ai.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/synology-media-proxy/ingress.yaml
+++ b/apps/synology-media-proxy/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: synology-media-proxy-ingress
   namespace: homelab
   annotations:
-    cert-manager.io/cluster-issuer: mkcert-issuer
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
@@ -14,13 +13,11 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - mp.wst.sh
-      secretName: mp-wst-sh-tls
+        - mp.realtong.cn
     - hosts:
-        - emby.wst.sh
-      secretName: emby-wst-sh-tls
+        - emby.realtong.cn
   rules:
-    - host: mp.wst.sh
+    - host: mp.realtong.cn
       http:
         paths:
           - path: /
@@ -30,7 +27,7 @@ spec:
                 name: moviepilot-external
                 port:
                   number: 13000
-    - host: emby.wst.sh
+    - host: emby.realtong.cn
       http:
         paths:
           - path: /

--- a/apps/uptime-kuma/ingress.yaml
+++ b/apps/uptime-kuma/ingress.yaml
@@ -13,15 +13,13 @@ metadata:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - uptime.wst.sh
-          secretName: uptime-wst-sh-tls
+              - uptime.realtong.cn
     rules:
-        - host: uptime.wst.sh
+        - host: uptime.realtong.cn
           http:
               paths:
                   - path: /

--- a/apps/vaultwarden/configmap.yaml
+++ b/apps/vaultwarden/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vaultwarden-configmap
   namespace: homelab
 data:
-  DOMAIN: "https://pwd.wst.sh"
+  DOMAIN: "https://pwd.realtong.cn"
   WEBSOCKET_ENABLED: "true"
   SSO_ENABLED: "true"
   SSO_AUTHORITY: "https://id.realtong.cn"

--- a/apps/vaultwarden/ingress.yaml
+++ b/apps/vaultwarden/ingress.yaml
@@ -6,22 +6,20 @@ metadata:
     annotations:
         glance/icon: di:vaultwarden
         glance/name: "Vaultwarden"
-        glance/url: "https://pwd.wst.sh"
+        glance/url: "https://pwd.realtong.cn"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "25m"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
-        cert-manager.io/cluster-issuer: mkcert-issuer
 spec:
     ingressClassName: nginx
     tls:
         - hosts:
-              - pwd.wst.sh
-          secretName: pwd-wst-sh-tls
+              - pwd.realtong.cn
     rules:
-        - host: pwd.wst.sh
+        - host: pwd.realtong.cn
           http:
               paths:
                   - path: /

--- a/infrastructure/controllers/nfs-provisioner/release.yaml
+++ b/infrastructure/controllers/nfs-provisioner/release.yaml
@@ -15,7 +15,7 @@ spec:
         namespace: flux-system
   values:
     nfs:
-      server: nas.realtong.cn
+      server: 10.0.0.100
       path: /volume1/k3s-volume
     storageClass:
       name: nfs-client


### PR DESCRIPTION
## Summary
- fix Pocket ID rollout safety by switching it to `Recreate` so config/domain changes don't deadlock on the app lock
- update the NFS provisioner to use the NAS IP directly for future volumes, avoiding hostname drift during domain migration
- finish migrating remaining app-facing `wst.sh` URLs/hosts to `realtong.cn`
- add a dedicated wildcard certificate for `status.realtong.cn` / `*.status.realtong.cn`

## Operational note
- I also applied a one-time live compatibility fix on the cluster nodes so existing PVs that still reference `nas.wst.sh` can mount again; this restored the stuck Pocket ID rollout immediately.

## Validation
- verified Pocket ID is healthy in-cluster after the live fix
- `kubectl apply --dry-run=server` on all changed manifests
- `kubectl kustomize apps/openstatus`
- verified no remaining `*.wst.sh` YAML references in the repo
