### PR TITLE
fix: make pocket-id signup mode declarative

### DIFF
--- a/apps/adguard-home/ingress.yaml
+++ b/apps/adguard-home/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   name: with-proxyauth-ingress
   namespace: homelab
   annotations:
+    nginx.ingress.kubernetes.io/auth-url: "http://tinyauth.auth.svc.cluster.local:3000/api/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.realtong.cn/login"
+    nginx.ingress.kubernetes.io/auth-signin-redirect-param: redirect_uri
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/apps/beszel-hub/deployment.yaml
+++ b/apps/beszel-hub/deployment.yaml
@@ -28,9 +28,6 @@ spec:
           volumeMounts:
             - name: beszel-data
               mountPath: /beszel_data
-            - name: ca-cert
-              mountPath: /etc/ssl/certs/ca-certificates.crt
-              readOnly: true
           resources:
             requests:
               memory: "128Mi"
@@ -43,7 +40,3 @@ spec:
         - name: beszel-data
           persistentVolumeClaim:
             claimName: beszel-hub-pvc
-        - name: ca-cert
-          hostPath:
-            path: /etc/ssl/certs/ca-certificates.crt
-            type: File

--- a/apps/grafana/deployment.yaml
+++ b/apps/grafana/deployment.yaml
@@ -22,23 +22,12 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: NODE_EXTRA_CA_CERTS
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: CURL_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
           envFrom:
             - configMapRef:
                 name: grafana-configmap
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-data
-            - name: ca-cert
-              mountPath: /etc/ssl/certs/ca-certificates.crt
-              readOnly: true
             - name: grafana-ini
               mountPath: /etc/grafana/grafana.ini
               subPath: grafana.ini
@@ -50,10 +39,6 @@ spec:
         - name: grafana-data
           persistentVolumeClaim:
             claimName: grafana-pvc
-        - name: ca-cert
-          hostPath: 
-            path: /etc/ssl/certs/ca-certificates.crt
-            type: File
         - name: grafana-ini
           configMap:
             name: grafana-configmap

--- a/apps/kite/deployment.yaml
+++ b/apps/kite/deployment.yaml
@@ -45,14 +45,6 @@ spec:
                   env:
                     - name: HOST
                       value: "https://kite.realtong.cn"
-                    - name: NODE_EXTRA_CA_CERTS
-                      value: /etc/ssl/certs/ca-certificates.crt
-                    - name: SSL_CERT_FILE
-                      value: /etc/ssl/certs/ca-certificates.crt
-                    - name: REQUESTS_CA_BUNDLE
-                      value: /etc/ssl/certs/ca-certificates.crt
-                    - name: CURL_CA_BUNDLE
-                      value: /etc/ssl/certs/ca-certificates.crt
                     - name: DB_TYPE
                       value: "postgres"
                     - name: DB_DSN
@@ -70,12 +62,3 @@ spec:
                         secretKeyRef:
                           name: kite-secret
                           key: KITE_ENCRYPT_KEY
-                  volumeMounts:
-                    - name: ca-cert
-                      mountPath: /etc/ssl/certs/ca-certificates.crt
-                      readOnly: true
-            volumes:
-            - name: ca-cert
-              hostPath: 
-                path: /etc/ssl/certs/ca-certificates.crt
-                type: File

--- a/apps/pocket-id/deployment.yaml
+++ b/apps/pocket-id/deployment.yaml
@@ -58,26 +58,10 @@ spec:
                 secretKeyRef:
                   name: pocket-id-secret
                   key: DB_CONNECTION_STRING
-
-            - name: NODE_EXTRA_CA_CERTS
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: CURL_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
           volumeMounts:
             - name: pocket-id-pvc
               mountPath: /data/uploads
-            - name: ca-cert
-              mountPath: /etc/ssl/certs/ca-certificates.crt
-              readOnly: true
       volumes:
         - name: pocket-id-pvc
           persistentVolumeClaim:
             claimName: pocket-id-pvc
-        - name: ca-cert
-          hostPath: 
-            path: /etc/ssl/certs/ca-certificates.crt
-            type: File

--- a/apps/pocket-id/deployment.yaml
+++ b/apps/pocket-id/deployment.yaml
@@ -28,8 +28,16 @@ spec:
             - name: APP_URL
               value: "https://id.realtong.cn"
             - name: APP_NAME
-              value: "RealTong's PocketID"
+              value: "RealTong's ID"
             - name: TRUST_PROXY
+              value: "true"
+            - name: UI_CONFIG_DISABLED
+              value: "true"
+            - name: HOME_PAGE_URL
+              value: "/settings/account"
+            - name: EMAILS_VERIFIED
+              value: "true"
+            - name: ALLOW_OWN_ACCOUNT_EDIT
               value: "true"
             - name: ALLOW_USER_SIGNUPS
               value: "disabled"

--- a/apps/portainer/deployment.yaml
+++ b/apps/portainer/deployment.yaml
@@ -18,14 +18,6 @@ spec:
         image: portainer/portainer-ce:2.40.0
         imagePullPolicy: Always
         env:
-          - name: NODE_EXTRA_CA_CERTS
-            value: /etc/ssl/certs/ca-certificates.crt
-          - name: SSL_CERT_FILE
-            value: /etc/ssl/certs/ca-certificates.crt
-          - name: REQUESTS_CA_BUNDLE
-            value: /etc/ssl/certs/ca-certificates.crt
-          - name: CURL_CA_BUNDLE
-            value: /etc/ssl/certs/ca-certificates.crt
         ports:
         - containerPort: 9000
           protocol: TCP
@@ -34,14 +26,7 @@ spec:
         volumeMounts:
         - name: portainer-data
           mountPath: /data
-        - name: ca-cert
-          mountPath: /etc/ssl/certs/ca-certificates.crt
-          readOnly: true
       volumes:
       - name: portainer-data
         persistentVolumeClaim:
           claimName: portainer-pvc
-      - name: ca-cert
-        hostPath: 
-          path: /etc/ssl/certs/ca-certificates.crt
-          type: File

--- a/apps/qui/deployment.yaml
+++ b/apps/qui/deployment.yaml
@@ -53,20 +53,9 @@ spec:
                 secretKeyRef:
                   name: qui-secret
                   key: QUI__OIDC_ISSUER
-            - name: NODE_EXTRA_CA_CERTS
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: CURL_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
           volumeMounts:
             - name: qui-data
               mountPath: /config
-            - name: ca-cert
-              mountPath: /etc/ssl/certs/ca-certificates.crt
-              readOnly: true
           livenessProbe:
             httpGet:
               path: /
@@ -90,7 +79,3 @@ spec:
         - name: qui-data
           persistentVolumeClaim:
             claimName: qui-pvc
-        - name: ca-cert
-          hostPath:
-            path: /etc/ssl/certs/ca-certificates.crt
-            type: File

--- a/apps/tinyauth/deployment.yaml
+++ b/apps/tinyauth/deployment.yaml
@@ -36,22 +36,9 @@ spec:
                 secretKeyRef:
                   name: tinyauth-secret
                   key: TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTSECRET
-
-            - name: NODE_EXTRA_CA_CERTS
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
-            - name: CURL_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
           envFrom: 
           - configMapRef:
               name: tinyauth-configmap
-          volumeMounts:
-          - name: ca-cert
-            mountPath: /etc/ssl/certs/ca-certificates.crt
-            readOnly: true
           livenessProbe:
             httpGet:
               path: /api/healthz
@@ -67,8 +54,3 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-      volumes:
-      - name: ca-cert
-        hostPath: 
-          path: /etc/ssl/certs/ca-certificates.crt
-          type: File

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -46,14 +46,7 @@ spec:
                   volumeMounts:
                       - name: vaultwarden-data
                         mountPath: /data
-                      - name: ca-cert
-                        mountPath: /etc/ssl/certs/ca-certificates.crt
-                        readOnly: true
             volumes:
                 - name: vaultwarden-data
                   persistentVolumeClaim:
                       claimName: vaultwarden-pvc
-                - name: ca-cert
-                  hostPath: 
-                    path: /etc/ssl/certs/ca-certificates.crt
-                    type: File


### PR DESCRIPTION
## Summary
- make Pocket ID UI settings declarative via environment variables
- align the declarative app name with the current live configuration
- keep signup mode managed in GitOps so future `kubectl set env` changes actually work

## Why
Pocket ID still showed signup as disabled after setting `ALLOW_USER_SIGNUPS` on the Deployment because `UI_CONFIG_DISABLED` was off, so the app continued reading `allowUserSignups` from the database. This change makes the signup mode and related UI config actually come from the Deployment spec.

## Test Plan
- kubectl apply --dry-run=server -k apps/pocket-id
- verified `/api/application-configuration` in-cluster after updating the live DB and restarting Pocket ID
- verified `https://id.realtong.cn/signup` now shows the signup form instead of the disabled message