### PR TITLE
fix(security): consolidate remaining Sentinel hardening

### DIFF
--- a/apps/grafana/configmap.yaml
+++ b/apps/grafana/configmap.yaml
@@ -9,5 +9,5 @@ data:
     root_url = https://dash.realtong.cn/
     
     [auth]
-    oauth_allow_insecure_email_lookup = true
+    oauth_allow_insecure_email_lookup = false
     disable_login_form = false

--- a/apps/grafana/deployment.yaml
+++ b/apps/grafana/deployment.yaml
@@ -15,19 +15,43 @@ spec:
       labels:
         app: grafana
     spec:
+      securityContext:
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+        runAsNonRoot: true
       containers:
         - name: grafana
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           image: grafana/grafana:12.4.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
           env:
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
+            - name: CURL_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
           envFrom:
             - configMapRef:
                 name: grafana-configmap
           volumeMounts:
+            - mountPath: /tmp
+              name: tmp-vol
             - mountPath: /var/lib/grafana
               name: grafana-data
+            - name: ca-cert
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
             - name: grafana-ini
               mountPath: /etc/grafana/grafana.ini
               subPath: grafana.ini
@@ -36,9 +60,15 @@ spec:
               cpu: 250m
               memory: 750Mi
       volumes:
+        - name: tmp-vol
+          emptyDir: {}
         - name: grafana-data
           persistentVolumeClaim:
             claimName: grafana-pvc
+        - name: ca-cert
+          hostPath: 
+            path: /etc/ssl/certs/ca-certificates.crt
+            type: File
         - name: grafana-ini
           configMap:
             name: grafana-configmap

--- a/apps/n8n/deployment.yaml
+++ b/apps/n8n/deployment.yaml
@@ -16,10 +16,20 @@ spec:
       labels:
         app: n8n
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       nodeSelector:
         kubernetes.io/hostname: "realtong-server"
       containers:
         - name: n8n
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           image: docker.n8n.io/n8nio/n8n:2.17.0
           ports:
             - containerPort: 5678
@@ -67,6 +77,8 @@ spec:
           volumeMounts:
             - name: n8n-data
               mountPath: /home/node/.n8n
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 100m
@@ -78,4 +90,6 @@ spec:
         - name: n8n-data
           persistentVolumeClaim:
             claimName: n8n-pvc
+        - name: tmp
+          emptyDir: {}
 

--- a/apps/prometheus/deployment.yaml
+++ b/apps/prometheus/deployment.yaml
@@ -15,8 +15,16 @@ spec:
       labels:
         app: prometheus
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
       containers:
         - name: prometheus
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           image: prom/prometheus:v3.11.1
           imagePullPolicy: IfNotPresent
           ports:
@@ -39,6 +47,8 @@ spec:
             - name: prometheus-config
               mountPath: /etc/prometheus/prometheus.yml
               subPath: prometheus.yml
+            - name: tmp-volume
+              mountPath: /tmp
           resources:
             requests:
               cpu: 250m
@@ -60,3 +70,5 @@ spec:
           hostPath: 
             path: /etc/ssl/certs/ca-certificates.crt
             type: File
+        - name: tmp-volume
+          emptyDir: {}

--- a/apps/redis/deployment.yaml
+++ b/apps/redis/deployment.yaml
@@ -16,13 +16,22 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
       containers:
         - name: redis
           image: redis:8-alpine
           command:
             - redis-server
             - /usr/local/etc/redis/redis.conf
-
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           envFrom:
             - secretRef:
                 name: redis-secret
@@ -34,6 +43,8 @@ spec:
               mountPath: /usr/local/etc/redis
             - name: redis-storage
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               memory: "128Mi"
@@ -48,3 +59,5 @@ spec:
         - name: redis-storage
           persistentVolumeClaim:
             claimName: redis-pvc
+        - name: tmp
+          emptyDir: {}

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -15,14 +15,26 @@ spec:
             labels:
                 app: vaultwarden
         spec:
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
             nodeSelector:
                 kubernetes.io/hostname: "realtong-server"
             containers:
                 - name: vaultwarden
                   image: vaultwarden/server:1.35.7
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop: ["ALL"]
                   ports:
-                      - containerPort: 80
+                      - containerPort: 8080
                   env:
+                      - name: ROCKET_PORT
+                        value: "8080"
                       - name: ADMIN_TOKEN
                         valueFrom:
                             secretKeyRef:
@@ -46,7 +58,18 @@ spec:
                   volumeMounts:
                       - name: vaultwarden-data
                         mountPath: /data
+                      - name: ca-cert
+                        mountPath: /etc/ssl/certs/ca-certificates.crt
+                        readOnly: true
+                      - name: tmp
+                        mountPath: /tmp
             volumes:
                 - name: vaultwarden-data
                   persistentVolumeClaim:
                       claimName: vaultwarden-pvc
+                - name: ca-cert
+                  hostPath: 
+                    path: /etc/ssl/certs/ca-certificates.crt
+                    type: File
+                - name: tmp
+                  emptyDir: {}

--- a/apps/vaultwarden/service.yaml
+++ b/apps/vaultwarden/service.yaml
@@ -11,7 +11,7 @@ spec:
     ports:
         - name: http
           port: 80
-          targetPort: 80
+          targetPort: 8080
         - name: websocket
           port: 3012
           targetPort: 3012


### PR DESCRIPTION
## Summary
- apply remaining Grafana, Redis, Prometheus, Vaultwarden, and n8n Sentinel security hardening on top of current main
- keep current image versions and realtong.cn domain updates while porting the security fixes
- disable Grafana insecure OAuth email lookup

## Validation
- kubectl kustomize apps/grafana
- kubectl kustomize apps/n8n
- kubectl kustomize apps/prometheus
- kubectl kustomize apps/redis
- kubectl kustomize apps/vaultwarden
- kubectl kustomize apps

Supersedes #62, #68, #70, #71, #73, #74.