### PR TITLE
fix(redis): repair pvc permissions before startup

### DIFF
--- a/apps/redis/deployment.yaml
+++ b/apps/redis/deployment.yaml
@@ -21,6 +21,31 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+      initContainers:
+        - name: fix-data-permissions
+          image: alpine:3.20
+          command:
+            - sh
+            - -lc
+            - |
+              set -eu
+              mkdir -p /data/appendonlydir
+              chown -R 999:999 /data
+              chmod 775 /data /data/appendonlydir
+              find /data -type d -exec chmod 775 {} \;
+              find /data -type f -exec chmod 664 {} \;
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: redis-storage
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
       containers:
         - name: redis
           image: redis:8-alpine


### PR DESCRIPTION
## Summary
- add an initContainer that repairs ownership and write permissions on the Redis PVC before Redis starts
- keep the non-root Redis securityContext while preventing AOF manifest permission failures on existing local-path data

## Root cause
Redis was crashlooping because the persisted data under /data was owned by root:root, while the hardened deployment now runs Redis as uid/gid 999. Redis could read the AOF files but failed to create temp-appendonly.aof.manifest with Permission denied.

## Validation
- kubectl kustomize apps/redis
- kubectl kustomize apps
- live cluster verification: Redis returned to Running after fixing PVC ownership and restarting the deployment