### PR TITLE
fix(glance): override beszel url to realtong domain

### DIFF
--- a/apps/glance/deployment.yaml
+++ b/apps/glance/deployment.yaml
@@ -27,6 +27,8 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: CURL_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
+            - name: BESZEL_URL
+              value: https://monitor.realtong.cn
           envFrom:
             - secretRef:
                 name: glance-secret


### PR DESCRIPTION
## Summary
- override BESZEL_URL in the Glance deployment so it uses monitor.realtong.cn even if the legacy Infisical secret value is still on monitor.wst.sh
- keep the secret-managed token in Infisical while moving the non-sensitive Beszel base URL into declarative GitOps config

## Validation
- kubectl kustomize apps
- live restart of glance and verification against current cluster logs