### PR TITLE
feat: add headscale and headplane

### DIFF
--- a/apps/headscale/configmap-headplane.yaml
+++ b/apps/headscale/configmap-headplane.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headplane-config
+  namespace: homelab
+data:
+  config.yaml: |
+    server:
+      host: 0.0.0.0
+      port: 3000
+      base_url: https://headscale.realtong.cn
+      cookie_secure: true
+      cookie_max_age: 86400
+      data_path: /var/lib/headplane
+
+    headscale:
+      url: http://headscale:8080
+      public_url: https://headscale.realtong.cn
+      config_path: /etc/headscale/config.yaml
+      config_strict: true
+
+    integration:
+      agent:
+        enabled: false
+      docker:
+        enabled: false
+      kubernetes:
+        enabled: false
+      proc:
+        enabled: false

--- a/apps/headscale/configmap-headscale.yaml
+++ b/apps/headscale/configmap-headscale.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-config
+  namespace: homelab
+data:
+  config.yaml: |
+    server_url: https://headscale.realtong.cn
+    listen_addr: 0.0.0.0:8080
+    metrics_listen_addr: 0.0.0.0:9090
+    grpc_listen_addr: 127.0.0.1:50443
+    grpc_allow_insecure: false
+
+    noise:
+      private_key_path: /var/lib/headscale/noise_private.key
+
+    prefixes:
+      v4: 100.64.0.0/10
+      v6: fd7a:115c:a1e0::/48
+      allocation: sequential
+
+    derp:
+      server:
+        enabled: false
+      urls:
+        - https://controlplane.tailscale.com/derpmap/default
+      paths: []
+      auto_update_enabled: true
+      update_frequency: 24h
+
+    disable_check_updates: false
+    ephemeral_node_inactivity_timeout: 30m
+
+    database:
+      type: sqlite
+      debug: false
+      sqlite:
+        path: /var/lib/headscale/db.sqlite
+        write_ahead_log: true
+
+    unix_socket: /var/run/headscale/headscale.sock
+    unix_socket_permission: "0770"
+
+    policy:
+      mode: database
+      path: ""
+
+    dns:
+      magic_dns: true
+      base_domain: tailnet.realtong.cn
+      override_local_dns: true
+      nameservers:
+        global:
+          - 1.1.1.1
+          - 1.0.0.1
+          - 2606:4700:4700::1111
+          - 2606:4700:4700::1001
+      search_domains: []

--- a/apps/headscale/deployment-headplane.yaml
+++ b/apps/headscale/deployment-headplane.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headplane
+  namespace: homelab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headplane
+  template:
+    metadata:
+      labels:
+        app: headplane
+    spec:
+      containers:
+        - name: headplane
+          image: ghcr.io/tale/headplane:v0.6.2
+          env:
+            - name: HEADPLANE_LOAD_ENV_OVERRIDES
+              value: "true"
+            - name: HEADPLANE_SERVER__COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_SERVER__COOKIE_SECRET
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: headplane-config
+              mountPath: /etc/headplane/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: headplane-data
+              mountPath: /var/lib/headplane
+            - name: headscale-config
+              mountPath: /etc/headscale/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: headplane-config
+          configMap:
+            name: headplane-config
+        - name: headplane-data
+          persistentVolumeClaim:
+            claimName: headplane-pvc
+        - name: headscale-config
+          configMap:
+            name: headscale-config

--- a/apps/headscale/deployment-headscale.yaml
+++ b/apps/headscale/deployment-headscale.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headscale
+  namespace: homelab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headscale
+  template:
+    metadata:
+      labels:
+        app: headscale
+    spec:
+      containers:
+        - name: headscale
+          image: headscale/headscale:0.28.0
+          args:
+            - serve
+          ports:
+            - containerPort: 8080
+            - containerPort: 9090
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: headscale-config
+              mountPath: /etc/headscale/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: headscale-data
+              mountPath: /var/lib/headscale
+            - name: headscale-run
+              mountPath: /var/run/headscale
+      volumes:
+        - name: headscale-config
+          configMap:
+            name: headscale-config
+        - name: headscale-data
+          persistentVolumeClaim:
+            claimName: headscale-pvc
+        - name: headscale-run
+          emptyDir: {}

--- a/apps/headscale/external-secret.yaml
+++ b/apps/headscale/external-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headplane-secret
+  namespace: homelab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: infisical-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: HEADPLANE_SERVER__COOKIE_SECRET
+      remoteRef:
+        key: /headscale/HEADPLANE_SERVER__COOKIE_SECRET

--- a/apps/headscale/ingress.yaml
+++ b/apps/headscale/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: headscale-ingress
+  namespace: homelab
+  annotations:
+    glance/icon: di:tailscale
+    glance/name: "Headscale"
+    glance/url: "https://headscale.realtong.cn/admin"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - headscale.realtong.cn
+  rules:
+    - host: headscale.realtong.cn
+      http:
+        paths:
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: headplane
+                port:
+                  number: 3000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: headscale
+                port:
+                  number: 8080

--- a/apps/headscale/kustomization.yaml
+++ b/apps/headscale/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homelab
+resources:
+  - ./configmap-headscale.yaml
+  - ./configmap-headplane.yaml
+  - ./external-secret.yaml
+  - ./pvc-headscale.yaml
+  - ./pvc-headplane.yaml
+  - ./deployment-headscale.yaml
+  - ./deployment-headplane.yaml
+  - ./service-headscale.yaml
+  - ./service-headplane.yaml
+  - ./ingress.yaml

--- a/apps/headscale/pvc-headplane.yaml
+++ b/apps/headscale/pvc-headplane.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: headplane-pvc
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-client
+  resources:
+    requests:
+      storage: 512Mi

--- a/apps/headscale/pvc-headscale.yaml
+++ b/apps/headscale/pvc-headscale.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: headscale-pvc
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-client
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/headscale/service-headplane.yaml
+++ b/apps/headscale/service-headplane.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: headplane
+  name: headplane
+  namespace: homelab
+spec:
+  ports:
+    - name: http
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: headplane

--- a/apps/headscale/service-headscale.yaml
+++ b/apps/headscale/service-headscale.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: headscale
+  name: headscale
+  namespace: homelab
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: headscale

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
   - ./adguard-home/
   - ./pve/
   - ./qui/
+  - ./headscale/


### PR DESCRIPTION
## Summary
- add GitOps manifests for Headscale and Headplane in the `homelab` namespace
- expose Headscale on `https://headscale.realtong.cn/` and Headplane on `https://headscale.realtong.cn/admin`
- keep Headplane cookie secret out of git by sourcing it from Infisical via ExternalSecret

## Validation
- `kubectl kustomize ./apps/headscale`
- `kubectl apply --dry-run=server -k ./apps/headscale`
- `kubectl kustomize ./apps`

## Notes
- `headscale.realtong.cn` must not use Cloudflare Proxy / Cloudflare Tunnel because Headscale requires WebSocket POST support.
- This PR references the secret path `/headscale/HEADPLANE_SERVER__COOKIE_SECRET`; the secret value itself is not committed.
- MagicDNS base domain is set to `tailnet.realtong.cn`.
