### PR TITLE
fix(headplane): correct image tag and probes

### DIFF
--- a/apps/headscale/configmap-headplane.yaml
+++ b/apps/headscale/configmap-headplane.yaml
@@ -22,9 +22,11 @@ data:
     integration:
       agent:
         enabled: false
+        pre_authkey: ""
       docker:
         enabled: false
       kubernetes:
         enabled: false
+        pod_name: headscale
       proc:
         enabled: false

--- a/apps/headscale/deployment-headplane.yaml
+++ b/apps/headscale/deployment-headplane.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: headplane
-          image: ghcr.io/tale/headplane:v0.6.2
+          image: ghcr.io/tale/headplane:0.6.2
           env:
             - name: HEADPLANE_LOAD_ENV_OVERRIDES
               value: "true"
@@ -26,14 +26,20 @@ spec:
                   key: HEADPLANE_SERVER__COOKIE_SECRET
           ports:
             - containerPort: 3000
+          startupProbe:
+            exec:
+              command:
+                - /bin/hp_healthcheck
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 3000
+            exec:
+              command:
+                - /bin/hp_healthcheck
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 3000
+            exec:
+              command:
+                - /bin/hp_healthcheck
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary
- switch Headplane from the non-existent `ghcr.io/tale/headplane:v0.6.2` tag to the valid `ghcr.io/tale/headplane:0.6.2` tag
- replace the broken `/healthz` HTTP probes with the image's built-in `/bin/hp_healthcheck` exec probe
- add the disabled-integration fields Headplane still validates (`integration.agent.pre_authkey`, `integration.kubernetes.pod_name`)

## Validation
- confirmed `ghcr.io/tale/headplane:v0.6.2` returns `MANIFEST_UNKNOWN` from GHCR
- confirmed `ghcr.io/tale/headplane:0.6.2` resolves successfully from GHCR
- `kubectl kustomize ./apps/headscale`
- YAML parse check for the edited manifests

## Notes
- I could not do live `kubectl` verification from this environment because the kube-apiserver is currently unreachable from here (`dial tcp 10.0.0.130:6443: connect: no route to host`).
- Redis needs live cluster inspection before I can say whether it is the old PVC permission issue again or a new failure.
