### PR TITLE
feat(headscale): add OIDC for headscale and headplane

### DIFF
--- a/apps/headscale/configmap-headplane.yaml
+++ b/apps/headscale/configmap-headplane.yaml
@@ -16,8 +16,11 @@ data:
     headscale:
       url: http://headscale:8080
       public_url: https://headscale.realtong.cn
-      config_path: /etc/headscale/config.yaml
       config_strict: true
+
+    oidc:
+      enabled: true
+      use_pkce: true
 
     integration:
       agent:

--- a/apps/headscale/configmap-headscale.yaml
+++ b/apps/headscale/configmap-headscale.yaml
@@ -4,7 +4,7 @@ metadata:
   name: headscale-config
   namespace: homelab
 data:
-  config.yaml: |
+  config.yaml.tmpl: |
     server_url: https://headscale.realtong.cn
     listen_addr: 0.0.0.0:8080
     metrics_listen_addr: 0.0.0.0:9090
@@ -44,6 +44,17 @@ data:
     policy:
       mode: database
       path: ""
+
+    oidc:
+      only_start_if_oidc_is_available: true
+      issuer: "__OIDC_ISSUER__"
+      client_id: "__OIDC_CLIENT_ID__"
+      client_secret_path: /etc/headscale/oidc-secrets/OIDC_CLIENT_SECRET
+      scope: ["openid", "profile", "email"]
+      email_verified_required: false
+      pkce:
+        enabled: true
+        method: S256
 
     dns:
       magic_dns: true

--- a/apps/headscale/deployment-headplane.yaml
+++ b/apps/headscale/deployment-headplane.yaml
@@ -17,13 +17,31 @@ spec:
         - name: headplane
           image: ghcr.io/tale/headplane:0.6.2
           env:
-            - name: HEADPLANE_LOAD_ENV_OVERRIDES
-              value: "true"
             - name: HEADPLANE_SERVER__COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
                   name: headplane-secret
                   key: HEADPLANE_SERVER__COOKIE_SECRET
+            - name: HEADPLANE_OIDC__ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_OIDC__ISSUER
+            - name: HEADPLANE_OIDC__CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_OIDC__CLIENT_ID
+            - name: HEADPLANE_OIDC__CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_OIDC__CLIENT_SECRET
+            - name: HEADPLANE_HEADSCALE__API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_HEADSCALE__API_KEY
           ports:
             - containerPort: 3000
           startupProbe:
@@ -54,10 +72,6 @@ spec:
               readOnly: true
             - name: headplane-data
               mountPath: /var/lib/headplane
-            - name: headscale-config
-              mountPath: /etc/headscale/config.yaml
-              subPath: config.yaml
-              readOnly: true
       volumes:
         - name: headplane-config
           configMap:
@@ -65,6 +79,3 @@ spec:
         - name: headplane-data
           persistentVolumeClaim:
             claimName: headplane-pvc
-        - name: headscale-config
-          configMap:
-            name: headscale-config

--- a/apps/headscale/deployment-headscale.yaml
+++ b/apps/headscale/deployment-headscale.yaml
@@ -13,6 +13,37 @@ spec:
       labels:
         app: headscale
     spec:
+      initContainers:
+        - name: render-config
+          image: python:3.12-alpine
+          env:
+            - name: OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: headscale-secret
+                  key: OIDC_ISSUER
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: headscale-secret
+                  key: OIDC_CLIENT_ID
+          command:
+            - python
+            - -c
+            - |
+              from pathlib import Path
+              import os
+              template = Path('/config-template/config.yaml.tmpl').read_text()
+              rendered = (template
+                  .replace('__OIDC_ISSUER__', os.environ['OIDC_ISSUER'])
+                  .replace('__OIDC_CLIENT_ID__', os.environ['OIDC_CLIENT_ID']))
+              Path('/rendered/config.yaml').write_text(rendered)
+          volumeMounts:
+            - name: headscale-config-template
+              mountPath: /config-template
+              readOnly: true
+            - name: headscale-config-rendered
+              mountPath: /rendered
       containers:
         - name: headscale
           image: headscale/headscale:0.28.0
@@ -37,18 +68,26 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-            - name: headscale-config
+            - name: headscale-config-rendered
               mountPath: /etc/headscale/config.yaml
               subPath: config.yaml
+              readOnly: true
+            - name: headscale-oidc-secret
+              mountPath: /etc/headscale/oidc-secrets
               readOnly: true
             - name: headscale-data
               mountPath: /var/lib/headscale
             - name: headscale-run
               mountPath: /var/run/headscale
       volumes:
-        - name: headscale-config
+        - name: headscale-config-template
           configMap:
             name: headscale-config
+        - name: headscale-config-rendered
+          emptyDir: {}
+        - name: headscale-oidc-secret
+          secret:
+            secretName: headscale-secret
         - name: headscale-data
           persistentVolumeClaim:
             claimName: headscale-pvc

--- a/apps/headscale/external-secret.yaml
+++ b/apps/headscale/external-secret.yaml
@@ -11,4 +11,37 @@ spec:
   data:
     - secretKey: HEADPLANE_SERVER__COOKIE_SECRET
       remoteRef:
-        key: /headscale/HEADPLANE_SERVER__COOKIE_SECRET
+        key: /Headplane/HEADPLANE_SERVER__COOKIE_SECRET
+    - secretKey: HEADPLANE_OIDC__ISSUER
+      remoteRef:
+        key: /Headplane/ISSUER
+    - secretKey: HEADPLANE_OIDC__CLIENT_ID
+      remoteRef:
+        key: /Headplane/CLIENT_ID
+    - secretKey: HEADPLANE_OIDC__CLIENT_SECRET
+      remoteRef:
+        key: /Headplane/CLIENT_SECRET
+    - secretKey: HEADPLANE_HEADSCALE__API_KEY
+      remoteRef:
+        key: /Headplane/HEADSCALE_API_KEY
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headscale-secret
+  namespace: homelab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: infisical-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: OIDC_ISSUER
+      remoteRef:
+        key: /headscale/ISSUER
+    - secretKey: OIDC_CLIENT_ID
+      remoteRef:
+        key: /headscale/CLIENT_ID
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: /headscale/CLIENT_SECRET


### PR DESCRIPTION
## Summary
- enable OIDC/SSO for both Headscale and Headplane
- source all OIDC values from Infisical-backed ExternalSecrets instead of committing them
- render the Headscale config at startup so issuer/client ID stay out of git while `client_secret` is read from a mounted secret file
- switch Headplane's existing cookie secret lookup to the correct `/Headplane/...` Infisical folder casing

## Validation
- `kubectl kustomize ./apps/headscale`
- `kubectl apply --dry-run=server -k ./apps/headscale`
- verified the live cluster is reachable and the existing Headscale deployment is healthy enough to answer `headscale version`

## Required Infisical keys
Headplane folder: `/Headplane`
- `HEADPLANE_SERVER__COOKIE_SECRET`
- `ISSUER`
- `CLIENT_ID`
- `CLIENT_SECRET`
- `HEADSCALE_API_KEY`  <-- add the Headscale API key here

Headscale folder: `/headscale`
- `ISSUER`
- `CLIENT_ID`
- `CLIENT_SECRET`

## Important notes
- Headplane needs its own `HEADSCALE_API_KEY` secret for SSO; OIDC alone is not enough.
- I removed the deprecated `HEADPLANE_LOAD_ENV_OVERRIDES` env var because Headplane 0.6.2 now loads config env overrides automatically.
- Headscale OIDC is configured with PKCE (`S256`) enabled.
