### PR TITLE
fix(headplane): add oidc headscale api key env

### DIFF
--- a/apps/headscale/deployment-headplane.yaml
+++ b/apps/headscale/deployment-headplane.yaml
@@ -42,6 +42,11 @@ spec:
                 secretKeyRef:
                   name: headplane-secret
                   key: HEADPLANE_HEADSCALE__API_KEY
+            - name: HEADPLANE_OIDC__HEADSCALE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: headplane-secret
+                  key: HEADPLANE_HEADSCALE__API_KEY
           ports:
             - containerPort: 3000
           startupProbe:


### PR DESCRIPTION
## Summary
- add `HEADPLANE_OIDC__HEADSCALE_API_KEY` to the Headplane deployment
- keep it sourced from the existing `HEADPLANE_HEADSCALE__API_KEY` secret entry

## Why
Headplane 0.6.2 failed startup with:
- `oidc.headscale_api_key must be a string (was missing)`

Even though `headscale.api_key` was already present, the OIDC validator still required the deprecated `oidc.headscale_api_key` field in this release.

## Validation
- `kubectl kustomize ./apps/headscale`
- `kubectl apply --dry-run=server -k ./apps/headscale`
- verified live cluster secrets after forced ExternalSecret refresh:
  - `headplane-secret` -> `SecretSynced`
  - `headscale-secret` -> `SecretSynced`
