### PR TITLE
fix: include manifest auth secret in rendered secret

### DIFF
--- a/apps/manifest/external-secret.yaml
+++ b/apps/manifest/external-secret.yaml
@@ -16,6 +16,7 @@ spec:
       data:
         DATABASE_URL: "postgresql://RealTong:{{ .POSTGRES_PASSWORD | urlquery }}@postgres.databases.svc.cluster.local:5432/manifest"
         BETTER_AUTH_URL: "https://ai.realtong.cn"
+        BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
   data:
     - secretKey: BETTER_AUTH_SECRET
       remoteRef:


### PR DESCRIPTION
## Summary
- include BETTER_AUTH_SECRET in the rendered Kubernetes Secret for Manifest
- keep DATABASE_URL templated from the shared postgres password

## Validation
- kubectl kustomize apps/manifest
