### PR TITLE
chore: update pocket-id to v2.6.2

### DIFF
--- a/apps/pocket-id/deployment.yaml
+++ b/apps/pocket-id/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
         - name: pocket-id
-          image: ghcr.io/pocket-id/pocket-id:v2.6.0
+          image: ghcr.io/pocket-id/pocket-id:v2.6.2
           ports:
             - containerPort: 1411
           env:


### PR DESCRIPTION
## Summary
- bump `ghcr.io/pocket-id/pocket-id` from `v2.6.0` to `v2.6.2`
- pick up upstream 2.6.1/2.6.2 bug fixes, including login background restoration and accessibility/HEAD response fixes

## Validation
- `kubectl kustomize ./apps`
- `kubectl kustomize ./infrastructure/controllers`
- `kubectl kustomize ./clusters/my-cluster/flux-system`