### PR TITLE
chore: rename media automation domains

### DIFF
--- a/apps/media-automation-proxy/ingress.yaml
+++ b/apps/media-automation-proxy/ingress.yaml
@@ -16,13 +16,13 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - radarr.realtong.cn
+        - movie.realtong.cn
     - hosts:
-        - sonarr.realtong.cn
+        - tv.realtong.cn
     - hosts:
-        - prowlarr.realtong.cn
+        - pt.realtong.cn
   rules:
-    - host: radarr.realtong.cn
+    - host: movie.realtong.cn
       http:
         paths:
           - path: /
@@ -32,7 +32,7 @@ spec:
                 name: radarr-external
                 port:
                   number: 17878
-    - host: sonarr.realtong.cn
+    - host: tv.realtong.cn
       http:
         paths:
           - path: /
@@ -42,7 +42,7 @@ spec:
                 name: sonarr-external
                 port:
                   number: 18989
-    - host: prowlarr.realtong.cn
+    - host: pt.realtong.cn
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary
- rename `sonarr.realtong.cn` to `tv.realtong.cn`
- rename `radarr.realtong.cn` to `movie.realtong.cn`
- rename `prowlarr.realtong.cn` to `pt.realtong.cn`

## Validation
- `kubectl kustomize ./apps`
- `kubectl kustomize ./infrastructure/controllers`
- `kubectl kustomize ./clusters/my-cluster/flux-system`