### PR TITLE
fix: move immich app storage to nfs

### DIFF
--- a/apps/immich/deployment.yaml
+++ b/apps/immich/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       volumes:
         - name: immich-data
           persistentVolumeClaim:
-            claimName: immich-data-pvc
+            claimName: immich-data-pvc-nfs
         - name: immich-external-library
           persistentVolumeClaim:
             claimName: immich-external-library-pvc
@@ -134,4 +134,4 @@ spec:
       volumes:
         - name: model-cache
           persistentVolumeClaim:
-            claimName: immich-model-cache-pvc
+            claimName: immich-model-cache-pvc-nfs

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./postgres-service.yaml
   - ./postgres-deployment.yaml
   - ./pvc.yaml
+  - ./pvc-nfs.yaml
   - ./external-library.yaml
   - ./service.yaml
   - ./deployment.yaml

--- a/apps/immich/pvc-nfs.yaml
+++ b/apps/immich/pvc-nfs.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-data-pvc-nfs
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-client
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-model-cache-pvc-nfs
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-client
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/immich/pvc.yaml
+++ b/apps/immich/pvc.yaml
@@ -10,16 +10,3 @@ spec:
   resources:
     requests:
       storage: 20Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: immich-model-cache-pvc
-  namespace: homelab
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: 10Gi


### PR DESCRIPTION
## Summary
- move Immich app data from local-path to NFS-backed PVC
- move Immich ML model cache from local-path to NFS-backed PVC
- keep immich-postgres on local-path as requested
- stop declaring the old local model-cache PVC in GitOps

## Live migration status
- Flux apps kustomization has been temporarily suspended
- `immich` and `immich-machine-learning` have been scaled to 0 for migration
- NFS PVCs have been created live
- data copy from old local `immich-data-pvc` to new `immich-data-pvc-nfs` is currently in progress

## Validation
- `kubectl kustomize ./apps/immich`
- `kubectl apply --dry-run=server -k ./apps/immich`
- `kubectl kustomize ./apps`

## Notes
- `immich-postgres-pvc` remains on `local-path`
- old `immich-data-pvc` is intentionally left in place for now as a rollback/back-up source until cutover is verified