### PR TITLE
Deploy Multica

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -31,3 +31,4 @@ resources:
   - ./pve/
   - ./qui/
   - ./immich/
+  - ./multica/

--- a/apps/multica/backend-deployment.yaml
+++ b/apps/multica/backend-deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multica-backend
+  namespace: homelab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multica-backend
+  template:
+    metadata:
+      labels:
+        app: multica-backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/multica-ai/multica-backend:v0.2.26
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: DATABASE_URL
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: JWT_SECRET
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: RESEND_API_KEY
+            - name: ALLOWED_EMAILS
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: ALLOWED_EMAILS
+            - name: REALTIME_METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: REALTIME_METRICS_TOKEN
+            - name: PORT
+              value: "8080"
+            - name: APP_ENV
+              value: production
+            - name: FRONTEND_ORIGIN
+              value: https://multica.realtong.cn
+            - name: CORS_ALLOWED_ORIGINS
+              value: https://multica.realtong.cn
+            - name: MULTICA_APP_URL
+              value: https://multica.realtong.cn
+            - name: LOCAL_UPLOAD_DIR
+              value: /app/data/uploads
+            - name: LOCAL_UPLOAD_BASE_URL
+              value: https://multica.realtong.cn
+            - name: RESEND_FROM_EMAIL
+              value: noreply@realtong.cn
+            - name: GOOGLE_CLIENT_ID
+              value: ""
+            - name: GOOGLE_REDIRECT_URI
+              value: https://multica.realtong.cn/auth/callback
+            - name: COOKIE_DOMAIN
+              value: ""
+            - name: ALLOW_SIGNUP
+              value: "true"
+          volumeMounts:
+            - name: backend-uploads
+              mountPath: /app/data/uploads
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+      volumes:
+        - name: backend-uploads
+          persistentVolumeClaim:
+            claimName: multica-uploads-pvc

--- a/apps/multica/backend-service.yaml
+++ b/apps/multica/backend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multica-backend
+  namespace: homelab
+spec:
+  selector:
+    app: multica-backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/apps/multica/external-secret.yaml
+++ b/apps/multica/external-secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: multica-secret
+  namespace: homelab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: infisical-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: /Multica/POSTGRES_PASSWORD
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: /Multica/DATABASE_URL
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: /Multica/JWT_SECRET
+    - secretKey: RESEND_API_KEY
+      remoteRef:
+        key: /Multica/RESEND_API_KEY
+    - secretKey: ALLOWED_EMAILS
+      remoteRef:
+        key: /Multica/ALLOWED_EMAILS
+    - secretKey: REALTIME_METRICS_TOKEN
+      remoteRef:
+        key: /Multica/REALTIME_METRICS_TOKEN

--- a/apps/multica/ingress.yaml
+++ b/apps/multica/ingress.yaml
@@ -1,0 +1,59 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: multica-ingress
+  namespace: homelab
+  annotations:
+    glance/icon: simple-icons:openai
+    glance/name: "Multica"
+    glance/url: "https://multica.realtong.cn"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - multica.realtong.cn
+  rules:
+    - host: multica.realtong.cn
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /ws
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /auth
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /uploads
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-web
+                port:
+                  number: 3000

--- a/apps/multica/kustomization.yaml
+++ b/apps/multica/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - postgres-pvc.yaml
+  - uploads-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - web-deployment.yaml
+  - web-service.yaml
+  - ingress.yaml

--- a/apps/multica/postgres-deployment.yaml
+++ b/apps/multica/postgres-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multica-postgres
+  namespace: homelab
+  annotations:
+    glance/icon: di:postgres
+    glance/name: "Multica PostgreSQL"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multica-postgres
+  template:
+    metadata:
+      labels:
+        app: multica-postgres
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: "realtong-server"
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg17
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: multica
+            - name: POSTGRES_USER
+              value: multica
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - multica
+                - -d
+                - multica
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: multica-postgres-pvc

--- a/apps/multica/postgres-pvc.yaml
+++ b/apps/multica/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: multica-postgres-pvc
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/multica/postgres-service.yaml
+++ b/apps/multica/postgres-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multica-postgres
+  namespace: homelab
+spec:
+  selector:
+    app: multica-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  type: ClusterIP

--- a/apps/multica/uploads-pvc.yaml
+++ b/apps/multica/uploads-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: multica-uploads-pvc
+  namespace: homelab
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-client
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/multica/web-deployment.yaml
+++ b/apps/multica/web-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multica-web
+  namespace: homelab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multica-web
+  template:
+    metadata:
+      labels:
+        app: multica-web
+    spec:
+      containers:
+        - name: web
+          image: ghcr.io/multica-ai/multica-web:v0.2.26
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: HOSTNAME
+              value: "0.0.0.0"
+            - name: REMOTE_API_URL
+              value: http://multica-backend:8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi

--- a/apps/multica/web-service.yaml
+++ b/apps/multica/web-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multica-web
+  namespace: homelab
+spec:
+  selector:
+    app: multica-web
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
## Summary\n- Deploy Multica at `https://multica.realtong.cn`\n- Add dedicated PostgreSQL 17 + pgvector deployment and PVC\n- Add Multica backend/web deployments using pinned `v0.2.26` GHCR images\n- Add ExternalSecret references for sensitive configuration via Infisical\n\n## Secrets required in Infisical\nCreate these keys before expecting the rollout to become healthy:\n- `/Multica/POSTGRES_PASSWORD`\n- `/Multica/DATABASE_URL` (`postgres://multica:<password>@multica-postgres.homelab.svc.cluster.local:5432/multica?sslmode=disable`)\n- `/Multica/JWT_SECRET`\n- `/Multica/RESEND_API_KEY`\n- `/Multica/ALLOWED_EMAILS`\n- `/Multica/REALTIME_METRICS_TOKEN`\n\n## Validation\n- `kubectl kustomize ./apps/multica`\n- `kubectl kustomize ./apps`\n- `kubectl kustomize ./infrastructure/controllers`\n- `kubectl kustomize ./clusters/my-cluster/flux-system`\n- `kubectl --context default apply --dry-run=server -k apps/multica`\n- `kubectl --context default apply --dry-run=server -k apps`\n