### PR TITLE
Fix Multica required secrets

### DIFF
--- a/apps/multica/backend-deployment.yaml
+++ b/apps/multica/backend-deployment.yaml
@@ -30,21 +30,6 @@ spec:
                 secretKeyRef:
                   name: multica-secret
                   key: JWT_SECRET
-            - name: RESEND_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: multica-secret
-                  key: RESEND_API_KEY
-            - name: ALLOWED_EMAILS
-              valueFrom:
-                secretKeyRef:
-                  name: multica-secret
-                  key: ALLOWED_EMAILS
-            - name: REALTIME_METRICS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: multica-secret
-                  key: REALTIME_METRICS_TOKEN
             - name: PORT
               value: "8080"
             - name: APP_ENV

--- a/apps/multica/external-secret.yaml
+++ b/apps/multica/external-secret.yaml
@@ -18,12 +18,3 @@ spec:
     - secretKey: JWT_SECRET
       remoteRef:
         key: /Multica/JWT_SECRET
-    - secretKey: RESEND_API_KEY
-      remoteRef:
-        key: /Multica/RESEND_API_KEY
-    - secretKey: ALLOWED_EMAILS
-      remoteRef:
-        key: /Multica/ALLOWED_EMAILS
-    - secretKey: REALTIME_METRICS_TOKEN
-      remoteRef:
-        key: /Multica/REALTIME_METRICS_TOKEN


### PR DESCRIPTION
## Summary\n- Keep only the minimum required Multica secrets in ExternalSecret:\n  - `POSTGRES_PASSWORD`\n  - `DATABASE_URL`\n  - `JWT_SECRET`\n- Leave Resend/OAuth/metrics optional so missing optional provider config does not block secret sync.\n\n## Validation\n- `kubectl kustomize ./apps/multica`\n- `kubectl kustomize ./apps`\n- `kubectl --context default apply --dry-run=server -k apps/multica`\n