### PR TITLE
Fix Multica database URL handling

### DIFF
--- a/apps/multica/backend-deployment.yaml
+++ b/apps/multica/backend-deployment.yaml
@@ -19,12 +19,21 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+          command:
+            - /bin/sh
+            - -c
+            - |
+              export DATABASE_URL="host=multica-postgres.homelab.svc.cluster.local port=5432 user=multica password=${POSTGRES_PASSWORD} dbname=multica sslmode=disable"
+              echo "Running database migrations..."
+              ./migrate up
+              echo "Starting server..."
+              exec ./server
           env:
-            - name: DATABASE_URL
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: multica-secret
-                  key: DATABASE_URL
+                  key: POSTGRES_PASSWORD
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/apps/multica/external-secret.yaml
+++ b/apps/multica/external-secret.yaml
@@ -12,9 +12,6 @@ spec:
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
         key: /Multica/POSTGRES_PASSWORD
-    - secretKey: DATABASE_URL
-      remoteRef:
-        key: /Multica/DATABASE_URL
     - secretKey: JWT_SECRET
       remoteRef:
         key: /Multica/JWT_SECRET


### PR DESCRIPTION
## Summary\n- Stop requiring `/Multica/DATABASE_URL` in Infisical\n- Build the backend database connection string from `POSTGRES_PASSWORD` at runtime using PostgreSQL keyword format\n- Avoid URL parsing failures when the generated database password contains reserved URL characters such as `:` or `@`\n\n## Validation\n- `kubectl kustomize ./apps/multica`\n- `kubectl kustomize ./apps`\n- `kubectl --context default apply --dry-run=server -k apps/multica`\n