### PR TITLE
Expose Multica app and API hosts

### DIFF
--- a/apps/multica/ingress.yaml
+++ b/apps/multica/ingress.yaml
@@ -18,7 +18,18 @@ spec:
   tls:
     - hosts:
         - multica.realtong.cn
+        - multica-api.realtong.cn
   rules:
+    - host: multica-api.realtong.cn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
     - host: multica.realtong.cn
       http:
         paths:
@@ -44,6 +55,27 @@ spec:
                 port:
                   number: 8080
           - path: /uploads
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /healthz
+            pathType: Prefix
+            backend:
+              service:
+                name: multica-backend
+                port:
+                  number: 8080
+          - path: /readyz
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary\n- Add `multica-api.realtong.cn` as a dedicated Multica backend/API host\n- Keep `multica.realtong.cn` as the frontend app host\n- Preserve same-host `/api`, `/ws`, `/auth`, `/uploads` routing for app compatibility\n- Route `/health`, `/healthz`, and `/readyz` on the app host to backend as well, so CLI health checks work even when using the app host\n\n## Validation\n- `kubectl kustomize ./apps/multica`\n- `kubectl kustomize ./apps`\n- `kubectl --context default apply --dry-run=server -k apps/multica`\n