### PR TITLE
Configure Multica email and allowlist

### DIFF
--- a/apps/multica/backend-deployment.yaml
+++ b/apps/multica/backend-deployment.yaml
@@ -39,6 +39,16 @@ spec:
                 secretKeyRef:
                   name: multica-secret
                   key: JWT_SECRET
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: RESEND_API_KEY
+            - name: ALLOWED_EMAILS
+              valueFrom:
+                secretKeyRef:
+                  name: multica-secret
+                  key: ALLOWED_EMAILS
             - name: PORT
               value: "8080"
             - name: APP_ENV
@@ -47,6 +57,8 @@ spec:
               value: https://multica.realtong.cn
             - name: CORS_ALLOWED_ORIGINS
               value: https://multica.realtong.cn
+            - name: ALLOWED_ORIGINS
+              value: https://multica.realtong.cn,https://multica-api.realtong.cn
             - name: MULTICA_APP_URL
               value: https://multica.realtong.cn
             - name: LOCAL_UPLOAD_DIR
@@ -62,6 +74,8 @@ spec:
             - name: COOKIE_DOMAIN
               value: ""
             - name: ALLOW_SIGNUP
+              value: "true"
+            - name: ANALYTICS_DISABLED
               value: "true"
           volumeMounts:
             - name: backend-uploads

--- a/apps/multica/external-secret.yaml
+++ b/apps/multica/external-secret.yaml
@@ -15,3 +15,9 @@ spec:
     - secretKey: JWT_SECRET
       remoteRef:
         key: /Multica/JWT_SECRET
+    - secretKey: RESEND_API_KEY
+      remoteRef:
+        key: /Multica/RESEND_API_KEY
+    - secretKey: ALLOWED_EMAILS
+      remoteRef:
+        key: /Multica/ALLOWED_EMAILS


### PR DESCRIPTION
## Summary\n- Wire `/Multica/RESEND_API_KEY` and `/Multica/ALLOWED_EMAILS` from Infisical into the Multica backend\n- Explicitly set `ALLOWED_ORIGINS` for both app and API hosts\n- Disable analytics explicitly with `ANALYTICS_DISABLED=true`\n\n## Validation\n- `kubectl kustomize ./apps/multica`\n- `kubectl kustomize ./apps`\n- `kubectl --context default apply --dry-run=server -k apps/multica`\n