### PR TITLE
chore: remove emby public exposure

### DIFF
--- a/apps/synology-media-proxy/ingress.yaml
+++ b/apps/synology-media-proxy/ingress.yaml
@@ -14,8 +14,6 @@ spec:
   tls:
     - hosts:
         - mp.realtong.cn
-    - hosts:
-        - emby.realtong.cn
   rules:
     - host: mp.realtong.cn
       http:
@@ -27,13 +25,3 @@ spec:
                 name: moviepilot-external
                 port:
                   number: 13000
-    - host: emby.realtong.cn
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: emby-external
-                port:
-                  number: 28096

--- a/apps/synology-media-proxy/services.yaml
+++ b/apps/synology-media-proxy/services.yaml
@@ -23,29 +23,3 @@ subsets:
       - name: http
         port: 13000
         protocol: TCP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: emby-external
-  namespace: homelab
-spec:
-  ports:
-    - name: http
-      port: 28096
-      protocol: TCP
-      targetPort: 28096
-  clusterIP: None
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: emby-external
-  namespace: homelab
-subsets:
-  - addresses:
-      - ip: 10.0.0.100 # 群晖 LAN IP
-    ports:
-      - name: http
-        port: 28096
-        protocol: TCP


### PR DESCRIPTION
## Summary
- removes the emby.realtong.cn ingress rule and TLS host from the Synology media proxy
- removes the emby-external Service and Endpoints from GitOps
- keeps the MoviePilot proxy unchanged

## Validation
- kubectl kustomize apps
- live cluster patched to remove the Emby route immediately