### PR TITLE
fix: restrict Kite Kubernetes secret access

### DIFF
--- a/apps/kite/deployment.yaml
+++ b/apps/kite/deployment.yaml
@@ -13,7 +13,7 @@ spec:
             labels:
                 app: kite
         spec:
-            serviceAccountName: cluster-admin-sa
+            serviceAccountName: kite
             nodeSelector:
                 kubernetes.io/hostname: "realtong-server"
             containers:

--- a/apps/kite/service-account.yaml
+++ b/apps/kite/service-account.yaml
@@ -1,19 +1,18 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-    name: cluster-admin-crb
-    namespace: observability
-roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: cluster-admin
-subjects:
-    - kind: ServiceAccount
-      name: cluster-admin-sa
-      namespace: observability
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: cluster-admin-sa
+  name: kite
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kite-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: kite
     namespace: observability


### PR DESCRIPTION
## Summary
- Replace Kite's cluster-admin ServiceAccount binding with a dedicated ServiceAccount bound to the built-in `view` ClusterRole
- Update Kite Deployment to run as the restricted `observability/kite` ServiceAccount
- Prevent Kite from reading/listing Kubernetes Secrets while keeping read-only visibility for normal resources

## Validation
- `kubectl kustomize apps/kite`
- `kubectl apply --dry-run=server -k apps/kite`
- Live verification: `kubectl auth can-i get secrets --as=system:serviceaccount:observability:kite -A` => `no`
- Live verification: `kubectl auth can-i list secrets --as=system:serviceaccount:observability:kite -A` => `no`
- Live verification: `kubectl auth can-i get pods --as=system:serviceaccount:observability:kite -A` => `yes`
- Live Kite rollout completed and health checks passed

Note: I also applied the RBAC restriction live immediately for safety; merging this PR makes it persistent in GitOps.