### PR TITLE
fix: revert external-secrets chart range

### DIFF
--- a/infrastructure/controllers/external-secrets/release.yaml
+++ b/infrastructure/controllers/external-secrets/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: "2.5.x"
+      version: "2.4.x"
       sourceRef:
         kind: HelmRepository
         name: external-secrets


### PR DESCRIPTION
Reverts external-secrets HelmRelease range from 2.5.x back to 2.4.x after the upgrade caused the 1Password ClusterSecretStore to stay NotReady with provider client creation failures / rate limit errors. Validation: kubectl kustomize ./infrastructure/controllers