### PR TITLE
fix: revert app updates with failed rollouts

### DIFF
--- a/apps/kube-state-metrics/deployment.yaml
+++ b/apps/kube-state-metrics/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: cluster-admin-sa
       containers:
         - name: kube-state-metrics 
-          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.0
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
           ports:
             - containerPort: 8080
           resources:

--- a/apps/multica/backend-deployment.yaml
+++ b/apps/multica/backend-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: ghcr.io/multica-ai/multica-backend:v0.3.5
+          image: ghcr.io/multica-ai/multica-backend:v0.3.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/apps/multica/web-deployment.yaml
+++ b/apps/multica/web-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: ghcr.io/multica-ai/multica-web:v0.3.5
+          image: ghcr.io/multica-ai/multica-web:v0.3.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/apps/portainer/deployment.yaml
+++ b/apps/portainer/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         kubernetes.io/hostname: "realtong-server"
       containers:
       - name: portainer
-        image: portainer/portainer-ce:2.42.0
+        image: portainer/portainer-ce:2.41.1
         imagePullPolicy: Always
         env:
         ports:

--- a/apps/sub2api/deployment.yaml
+++ b/apps/sub2api/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: "realtong-server"
       containers:
         - name: sub2api
-          image: weishaw/sub2api:0.1.129
+          image: weishaw/sub2api:0.1.126
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Reverts selected app image bumps from #175 that did not complete cleanly in the live cluster. kube-state-metrics and portainer cannot create replacement pods because observability/cluster-admin-sa is missing; multica backend v0.3.5 stayed past progress deadline; sub2api rollout is not clean while its postgres dependency is already unhealthy. Validation: kubectl kustomize ./apps