### PR TITLE
fix: roll back sub2api to healthy image

### DIFF
--- a/apps/sub2api/deployment.yaml
+++ b/apps/sub2api/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: "realtong-server"
       containers:
         - name: sub2api
-          image: weishaw/sub2api:0.1.126
+          image: weishaw/sub2api:0.1.125
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
The previously desired v0.1.126 cannot become Ready against the current live sub2api database state; the live healthy ReplicaSet is still v0.1.125. Roll Git back to the healthy image so Flux stops trying to roll out the crashing v0.1.126 pod. Validation: kubectl kustomize ./apps