### PR TITLE
fix: restore ExternalSecrets 1Password sync

### DIFF
--- a/infrastructure/controllers/external-secrets/release.yaml
+++ b/infrastructure/controllers/external-secrets/release.yaml
@@ -5,10 +5,17 @@ metadata:
   namespace: external-secrets
 spec:
   interval: 1h
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
   chart:
     spec:
       chart: external-secrets
-      version: "2.4.x"
+      # Pin to the first release after v2.4.1. v2.5.0 includes 1Password
+      # provider fixes; avoid floating "2.4.x" so Flux cannot remain on the
+      # broken runtime that makes all 1Password-backed ExternalSecrets fail.
+      version: "2.5.0"
       sourceRef:
         kind: HelmRepository
         name: external-secrets


### PR DESCRIPTION
## Summary
- Pins `external-secrets` from floating `2.4.x` to `2.5.0`.
- Enables Flux Helm CRD install/upgrade with `CreateReplace` for External Secrets CRDs.
- Targets the P0 issue where all 1Password-backed `ExternalSecret` reconciliations fail on v2.4.1 with `wasm error: out of bounds memory access`.

## Why
`external-secrets` v2.5.0 is the first chart/app release after the current live v2.4.1 and includes 1Password provider fixes. Pinning avoids staying on the broken 2.4.x runtime.

## Validation
- `kubectl kustomize infrastructure/controllers`
- `kubectl --context default apply --dry-run=server -k infrastructure/controllers`
- `kubectl --context default explain helmrelease.spec.install.crds`
- `kubectl --context default explain helmrelease.spec.upgrade.crds`
- Verified `external-secrets` chart `2.5.0` exists in `https://charts.external-secrets.io/index.yaml` with appVersion `v2.5.0`.

## Post-merge verification
```bash
flux --context default reconcile source git flux-system -n flux-system
flux --context default reconcile kustomization infra-controllers -n flux-system --with-source
flux --context default reconcile helmrelease external-secrets -n external-secrets
kubectl --context default -n external-secrets rollout status deploy/external-secrets --timeout=180s
kubectl --context default get externalsecret -A
kubectl --context default -n homelab annotate externalsecret vaultwarden-secret force-sync="$(date +%s)" --overwrite
kubectl --context default -n homelab describe externalsecret vaultwarden-secret
```
