### PR TITLE
fix: replace cluster-admin service account refs

### DIFF
--- a/apps/glance-k8s/deployment.yaml
+++ b/apps/glance-k8s/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: glance-k8s
     spec:
-      serviceAccountName: cluster-admin-sa
+      serviceAccountName: glance-k8s
       containers:
       - name: glance-k8s
         image: ghcr.io/lukasdietrich/glance-k8s/glance-k8s:v0.5.0

--- a/apps/glance-k8s/kustomization.yaml
+++ b/apps/glance-k8s/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 resources:  
+  - rbac.yaml
   - deployment.yaml
   - service.yaml

--- a/apps/glance-k8s/rbac.yaml
+++ b/apps/glance-k8s/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: glance-k8s
+  namespace: observability
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glance-k8s-readonly
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: glance-k8s-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glance-k8s-readonly
+subjects:
+  - kind: ServiceAccount
+    name: glance-k8s
+    namespace: observability

--- a/apps/kube-state-metrics/deployment.yaml
+++ b/apps/kube-state-metrics/deployment.yaml
@@ -12,10 +12,14 @@ spec:
       labels:
         app: kube-state-metrics
     spec: 
-      serviceAccountName: cluster-admin-sa
+      serviceAccountName: kube-state-metrics
       containers:
         - name: kube-state-metrics 
           image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          args:
+            # Exclude the secrets collector so this observability workload does
+            # not need RBAC that can read Kubernetes Secret data.
+            - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,endpointslices,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
           ports:
             - containerPort: 8080
           resources:

--- a/apps/kube-state-metrics/kustomization.yaml
+++ b/apps/kube-state-metrics/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 resources:  
+  - rbac.yaml
   - deployment.yaml
   - service.yaml

--- a/apps/kube-state-metrics/rbac.yaml
+++ b/apps/kube-state-metrics/rbac.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: observability
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics-readonly
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+      - services
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs: ["list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs: ["list", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - certificatesigningrequests
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: observability

--- a/apps/portainer/deployment.yaml
+++ b/apps/portainer/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: portainer
     spec:
-      serviceAccountName: cluster-admin-sa
+      serviceAccountName: portainer
       nodeSelector:
         kubernetes.io/hostname: "realtong-server"
       containers:

--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 resources:  
+  - rbac.yaml
   - deployment.yaml
   - pvc.yaml
   - ingress.yaml

--- a/apps/portainer/rbac.yaml
+++ b/apps/portainer/rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portainer
+  namespace: observability
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: portainer-kubernetes-view
+rules:
+  - nonResourceURLs:
+      - /version
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portainer-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: portainer
+    namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portainer-kubernetes-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: portainer-kubernetes-view
+subjects:
+  - kind: ServiceAccount
+    name: portainer
+    namespace: observability


### PR DESCRIPTION
## Summary
- Replace the nonexistent `cluster-admin-sa` references in `kube-state-metrics`, `glance-k8s`, and `portainer` with dedicated ServiceAccounts.
- Add least-privilege RBAC for each workload instead of granting or depending on cluster-admin access.
- Exclude the kube-state-metrics secrets collector so it does not need permission to read Kubernetes Secret data.
- Cleaned up the live orphaned `kube-state-metrics` ClusterRoleBinding that granted `cluster-admin` to a ServiceAccount in the missing `monitor` namespace.

## Validation
- `kubectl kustomize apps/kube-state-metrics`
- `kubectl kustomize apps/glance-k8s`
- `kubectl kustomize apps/portainer`
- `kubectl --context default apply --dry-run=server -f /tmp/ksm.yaml`
- `kubectl --context default apply --dry-run=server -f /tmp/glance-k8s.yaml`
- `kubectl --context default apply --dry-run=server -f /tmp/portainer.yaml`
- `kubectl --context default apply --dry-run=server -k apps`
- Python YAML/render checks confirmed no rendered `cluster-admin-sa` or `cluster-admin` roleRef in `apps`.
